### PR TITLE
use open_novisit() to download content (fixing earlier hotfix 0443f54)

### DIFF
--- a/desire2download.py
+++ b/desire2download.py
@@ -219,7 +219,8 @@ class Desire2Download(object):
                     
                 clean_url =  url.replace(' ', '%20')
                 
-                if 'https://learn.uwaterloo.ca/d2l/common/dialogs/' in url:
+                if 'https://learn.uwaterloo.ca/d2l/common/dialogs/' in url \
+                    or 'https://learn.uwaterloo.ca/d2l/lor/viewer/view.d2l' in url:
                     pass
                 
                 else:


### PR DESCRIPTION
The exceptions you added a hotfix for in 0443f54 seem to have been caused by the browser trying to add the response to the browser state (when downloading files). Using open_novisit() leaves the state unchanged and seems more appropriate for file downloading.

Also, it ignores urls with `https://learn.uwaterloo.ca/d2l/lor/viewer/view.d2l` since they are not files in the same sense as the others. It may be worth eventually adding support for this custom content type.
